### PR TITLE
Système de suppression de role client quand 0 bots

### DIFF
--- a/commands/STAFF/delete.js
+++ b/commands/STAFF/delete.js
@@ -26,11 +26,8 @@ class Delete extends Command {
         let botGet = await bots.findOne({ botID: args[0], verified: true });
         if (!botGet) return message.reply({ content: `**${client.no} ➜ Le bot ${member.user.tag} ne peut pas être supprimé car il n'est pas vérifié !**` });
         const member = await message.guild.members.fetch(botGet.botID);
-        
-
 
         if (!args.slice(1).join(" ")) return message.reply({ content: `**${client.no} ➜ Vous n'avez pas donné de raison de suppresion.` });
-        
         
         client.channels.cache.get(botslogs).send({
             content: `<@${botGet.ownerID}>`,
@@ -54,7 +51,7 @@ class Delete extends Command {
         const checkBot = await bots.find({ ownerId: botGet.ownerID });
           
         if (checkBot.lenght === 0) {
-            //code pour remove le role client du membre
+            message.guild.members.cache.get(botGet.ownerID)?.roles.remove(isclient);
         }
     }
 }

--- a/commands/STAFF/delete.js
+++ b/commands/STAFF/delete.js
@@ -50,6 +50,12 @@ class Delete extends Command {
         await bots.deleteOne({ botID: args[0] });
 
         if (autokick === true) member.kick();
+          
+        const checkBot = await bots.find({ ownerId: botGet.ownerID });
+          
+        if (checkBot.lenght === 0) {
+            //code pour remove le role client du membre
+        }
     }
 }
 


### PR DESCRIPTION
ça va permette de supprimer le rôle client du membre quand il ne possède aucun bots (grâce au check dans la db), mais si le membre possède 1 ou plus de bots après la suppression d'un bot il ne perd pas son bot.